### PR TITLE
fix: OG images returning Internal Server Error

### DIFF
--- a/src/app/categorias/[slug]/opengraph-image.tsx
+++ b/src/app/categorias/[slug]/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { OgTitleBar } from 'src/components/OgTitleBar';
 import { getCategory } from 'src/cms/categories';
 import { getFontData } from 'src/methods/getFontData';
 import { getRecipes } from 'src/cms/recipes';
+import { BASE_URL } from 'src/constants';
 
 type Params = {
   slug: string;
@@ -57,7 +58,7 @@ export default async function OpenGraphImage({
 
   if (category?.imagens) {
     const imageUrl = category?.imagens?.[id]?.url;
-    const fontData = await getFontData();
+    const fontData = getFontData();
 
     return new ImageResponse(
       (
@@ -107,7 +108,7 @@ export default async function OpenGraphImage({
       .slice(0, 4);
 
     if (recipeImages.length > 0) {
-      const fontData = await getFontData();
+      const fontData = getFontData();
 
       return new ImageResponse(
         (
@@ -148,7 +149,7 @@ export default async function OpenGraphImage({
     }
   }
 
-  const fontData = await getFontData();
+  const fontData = getFontData();
 
   return new ImageResponse(
     (
@@ -165,7 +166,7 @@ export default async function OpenGraphImage({
           backgroundColor: 'white',
         }}
       >
-        <img width="500" src="https://letscozinha.com.br/logo-texto.png" />
+        <img width="500" src={`${BASE_URL}/logo-texto.png`} />
         <p
           style={{
             fontFamily: '"PlayFair Display", serif',

--- a/src/app/ebooks/[slug]/opengraph-image.tsx
+++ b/src/app/ebooks/[slug]/opengraph-image.tsx
@@ -25,7 +25,7 @@ export default async function OpenGraphImage({
   params: Promise<Params>;
 }) {
   const ebook = await getEbook({ slug: (await params).slug });
-  const fontData = await getFontData();
+  const fontData = getFontData();
 
   const formattedPrice = ebook?.preco
     ? new Intl.NumberFormat('pt-BR', {

--- a/src/app/receitas/[slug]/opengraph-image.tsx
+++ b/src/app/receitas/[slug]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from 'next/og';
 import { OgTitleBar } from 'src/components/OgTitleBar';
 import { getRecipe } from 'src/cms/recipes';
 import { getFontData } from 'src/methods/getFontData';
+import { BASE_URL } from 'src/constants';
 
 type Params = {
   slug: string;
@@ -60,7 +61,7 @@ export default async function Image({
   const imageUrl = recipe?.imagens?.[id]?.url;
 
   if (!imageUrl) {
-    const fontData = await getFontData();
+    const fontData = getFontData();
 
     return new ImageResponse(
       (
@@ -77,7 +78,7 @@ export default async function Image({
             backgroundColor: 'white',
           }}
         >
-          <img width="500" src="https://letscozinha.com.br/logo-texto.png" />
+          <img width="500" src={`${BASE_URL}/logo-texto.png`} />
           <p
             style={{
               fontFamily: '"PlayFair Display", serif',
@@ -103,7 +104,7 @@ export default async function Image({
     );
   }
 
-  const fontData = await getFontData();
+  const fontData = getFontData();
 
   // Foto em cover (sem barras brancas) + barra de marca com o nome da
   // receita: og-images com título legível performam melhor em compartilhamentos

--- a/src/methods/getFontData.ts
+++ b/src/methods/getFontData.ts
@@ -1,6 +1,12 @@
-export const getFontData = async (): Promise<ArrayBuffer> => {
-  const response = await fetch(
-    new URL('../assets/PlayfairDisplay-Regular.ttf', import.meta.url)
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export const getFontData = (): ArrayBuffer => {
+  const buffer = readFileSync(
+    join(process.cwd(), 'public/assets/PlayfairDisplay-Regular.ttf')
   );
-  return response.arrayBuffer();
+  return buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength
+  ) as ArrayBuffer;
 };


### PR DESCRIPTION
## Summary

- **Root cause**: `getFontData.ts` used `fetch(new URL('../assets/...', import.meta.url))` to load the PlayFair Display font. In production Next.js builds, source files are bundled so `import.meta.url` points to the compiled bundle path (e.g. `.next/server/...`), not the original source location. The relative path then resolves to a non-existent file, causing an unhandled error → HTTP 500 on every OG image route.
- **Fix**: Replaced the `fetch`/`import.meta.url` approach with `fs.readFileSync(path.join(process.cwd(), 'public/assets/PlayfairDisplay-Regular.ttf'))`. This is reliable in Next.js Node.js runtime because `process.cwd()` always points to the project root and files in `public/` are always present.
- **Also fixed**: Hardcoded `https://letscozinha.com.br` (no `www`) in the logo fallback of `receitas` and `categorias` OG images — replaced with `BASE_URL` (`https://www.letscozinha.com.br`) for consistency.

## Test plan

- [ ] Deploy and open a recipe page (e.g. `/receitas/[slug]`) in the [Open Graph debugger](https://developers.facebook.com/tools/debug/) — image should load without error
- [ ] Same for a category page (`/categorias/[slug]`) and an e-book page (`/ebooks/[slug]`)
- [ ] Verify the fallback path (recipe with no image) renders logo + title correctly

https://claude.ai/code/session_011UHUe59p3nyDYDFvjbdpxY

---
_Generated by [Claude Code](https://claude.ai/code/session_011UHUe59p3nyDYDFvjbdpxY)_