### PR TITLE
fix: OG image CTA, recipe title prefix, description truncation

### DIFF
--- a/src/app/receitas/[slug]/opengraph-image.tsx
+++ b/src/app/receitas/[slug]/opengraph-image.tsx
@@ -88,6 +88,20 @@ export default async function Image({
           >
             {recipe?.nome}
           </p>
+          <div
+            style={{
+              display: 'flex',
+              backgroundColor: '#fab200',
+              color: '#333333',
+              fontFamily: '"PlayFair Display", serif',
+              fontSize: 36,
+              padding: '12px 40px',
+              borderRadius: 9999,
+              marginTop: 8,
+            }}
+          >
+            Ver receita →
+          </div>
         </div>
       ),
       {

--- a/src/app/receitas/[slug]/page.tsx
+++ b/src/app/receitas/[slug]/page.tsx
@@ -16,13 +16,12 @@ import { RecipeShare } from 'src/components/RecipeShare';
 import { RecipesList } from 'src/components/RecipesList';
 import { EmailSubscription } from 'src/components/EmailSubscription';
 import { getLetsCozinhaLets } from 'src/cms/singleTypes';
-import { getPageTitle } from 'src/methods/getPageTitle';
 import { getRecipeSchema } from 'src/methods/getRecipeSchema';
 import { getUrl } from 'src/methods/getUrl';
 import { getWebsiteName } from 'src/methods/getWebsiteName';
 import { notFound } from 'next/navigation';
 import type { Metadata, ResolvingMetadata } from 'next';
-import { FB_APP_ID } from 'src/constants';
+import { FB_APP_ID, WEBSITE_NAME } from 'src/constants';
 import { EbookCard } from 'src/components/EbookCard';
 import { ExclusiveRecipePreview } from 'src/components/ExclusiveRecipePreview';
 
@@ -59,18 +58,21 @@ export async function generateMetadata(
 
   const url = getUrl(`/receitas/${recipe.slug}`);
 
-  const title = getPageTitle(recipe.nome);
+  const title = `Receita de ${recipe.nome} | ${WEBSITE_NAME}`;
+
+  const rawDesc = recipe.meta_descricao ?? '';
+  const description = rawDesc.length > 125 ? rawDesc.slice(0, 122) + '...' : rawDesc;
 
   return {
     title,
-    description: recipe.meta_descricao,
+    description,
     keywords: recipe.keywords,
     alternates: {
       canonical: url,
     },
     openGraph: {
       title,
-      description: recipe.meta_descricao,
+      description,
       url,
       type: 'article',
       publishedTime: recipe.createdAt,

--- a/src/components/OgTitleBar.tsx
+++ b/src/components/OgTitleBar.tsx
@@ -39,11 +39,26 @@ export function OgTitleBar({ title }: { title?: string }) {
           fontSize: 52,
           color: 'white',
           margin: 0,
-          maxWidth: 1000,
+          flex: 1,
         }}
       >
         {title}
       </p>
+      <div
+        style={{
+          display: 'flex',
+          backgroundColor: '#fab200',
+          color: '#333333',
+          fontFamily: '"PlayFair Display", serif',
+          fontSize: 28,
+          padding: '10px 24px',
+          borderRadius: 9999,
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+        }}
+      >
+        Ver receita →
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Three improvements based on OpenGraph inspector warnings:

- **CTA in OG image**: Added a `"Ver receita →"` yellow pill (`#fab200`) to `OgTitleBar` (shown on recipe/category images with photos) and to the text-only fallback OG image (recipes with no photo). Addresses the "Missing call-to-action" warning.
- **Recipe title prefix**: Changed recipe page title from `"[nome] | Lets Cozinha"` (27 chars) to `"Receita de [nome] | Lets Cozinha"` to better use the 50–60 char SERP window.
- **Description truncation**: `og:description` now truncated to 125 chars (adds `…` if longer) to stay within social preview limits.

## Test plan

- [ ] Open a recipe with a photo in the OG debugger — "Ver receita →" pill should be visible in the bottom bar overlay
- [ ] Open a recipe with no photo — "Ver receita →" pill should appear below the title on white background
- [ ] Verify title shows "Receita de …" prefix in page `<title>` and og:title
- [ ] Verify og:description ≤ 125 chars for any recipe

https://claude.ai/code/session_011UHUe59p3nyDYDFvjbdpxY

---
_Generated by [Claude Code](https://claude.ai/code/session_011UHUe59p3nyDYDFvjbdpxY)_