### PR TITLE
fix(perf): eliminate footer CLS that fails Core Web Vitals

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -109,11 +109,18 @@ export default function RootLayout({
         <JsonLd schema={organizationSchema} />
         <Header />
         <main className="pb-xl md:pb-2xl">
-          <React.Suspense fallback={<div className="h-[200px]"></div>}>
-            {hero}
-          </React.Suspense>
+          <React.Suspense fallback={null}>{hero}</React.Suspense>
           <Container>
-            <div className="mx-auto my-lg md:my-xl flex flex-col md:flex-row gap-sm md:gap-xl">
+            {/*
+              `min-h-screen` reserva a altura do conteúdo principal enquanto ele
+              faz streaming. Sem essa reserva, o fallback de altura zero faz o
+              Footer renderizar dentro do viewport e depois ser empurrado para
+              baixo quando o conteúdo chega — gerando um CLS catastrófico
+              (~0.69). Reservando uma tela inteira, o Footer permanece abaixo da
+              dobra durante o carregamento e o deslocamento ocorre fora da tela,
+              sem contar para o CLS.
+            */}
+            <div className="mx-auto my-lg md:my-xl flex flex-col md:flex-row gap-sm md:gap-xl min-h-screen">
               <div className="w-full md:w-[70%]">
                 <React.Suspense fallback={null}>{children}</React.Suspense>
               </div>


### PR DESCRIPTION
## Context

The original request was to migrate the project from App Router to Pages Router "because App Router is bad for Web Vitals." Before doing that, I pulled the real data — and it pointed the other way, so we agreed to **diagnose the actual Web Vitals problem instead** of doing a large, risky rewrite that would have regressed performance.

## Diagnosis (from PageSpeed Insights / CrUX field data, mobile)

| Metric | Field | Lab | Verdict |
|---|---|---|---|
| **CLS** | **0.7** | **0.695** | 🔴 the sole cause of the "Failed" assessment |
| LCP | 2.8s | 4.6s | 🟠 secondary |
| INP | 104ms | — | 🟢 |
| TBT | — | 0 ms | 🟢 |
| TTFB | 0.6s | — | 🟢 |

`TBT = 0ms` and `INP = 104ms` are already green — JavaScript/hydration is optimal. That is exactly the area an App→Pages migration would have touched, confirming the migration was the wrong fix (and would likely have *worsened* CWV by shipping more client JS and losing the parallel-route hero/aside).

The PSI **"Layout shift culprits"** panel attributes **0.693 of the 0.695 CLS to the `<footer>`**.

## Root cause

Recipe pages stream, because `searchSimilarRecipes` (Meilisearch) and `getRecommendedEbook` are dynamic while CMS reads are `force-cache`. The shared `layout.tsx` wraps `{children}` in `<Suspense fallback={null}>`:

1. First paint → empty (zero-height) content area → the `<footer>` paints **inside the viewport**, right under the header.
2. Content streams in → the footer is shoved down by the full article height → **catastrophic layout shift**, on every page that uses this layout (hence field CLS ≈ 0.7 site-wide).

## Fix

Reserve a viewport of height (`min-h-screen`) for the streaming content area so the footer stays **below the fold** while content loads. Layout shifts that occur off-screen don't count toward CLS, so this removes the footer shift while **preserving streaming/FCP**. Also removed the unused `h-[200px]` hero fallback (the hero slot is sync-`null` on inner pages and supplies its own sized skeleton on the home page).

## Verification

- `tsc --noEmit` passes ✅
- `prettier --check` passes ✅
- Unit tests: the 2 failures in `getRecipeSchema.test.ts` are **pre-existing fixture drift** (confirmed on a clean tree, unrelated to this JSX change) ⚠️
- `next lint` is broken repo-wide (Next 16 removed the `next lint` subcommand) — pre-existing, unrelated ⚠️

## Recommended follow-ups (not in this PR)

- **Confirm with PSI after deploy** — re-run and verify CLS drops into the green and the assessment passes.
- **Home hero** (`@hero/page.tsx`): its skeleton is `h-[400px] md:h-[600px]` but the real hero is taller on mobile; likely a smaller residual CLS contributor worth re-checking once the footer fix is live.
- **LCP** (render delay 2710ms): drop legacy-JS polyfills via a modern browserslist (≈14 KiB) and inline/defer the render-blocking CSS chunk (≈190 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL6DWMkD34GDxowyoM4n27

---
_Generated by [Claude Code](https://claude.ai/code/session_01UL6DWMkD34GDxowyoM4n27)_