### PR TITLE
perf: remove Google Analytics and ship modern JS to cut unused JavaScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/react-fontawesome": "^3.3.1",
     "@google-analytics/data": "^6.1.0",
-    "@next/third-parties": "^16.2.9",
     "meilisearch": "^0.58.0",
     "next": "16.2.9",
     "next-mdx-remote-client": "^2.1.11",
@@ -63,5 +62,15 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.22.4",
     "typescript": "^6"
-  }
+  },
+  "browserslist": [
+    "chrome >= 92",
+    "edge >= 92",
+    "firefox >= 90",
+    "safari >= 15.4",
+    "ios_saf >= 15.4",
+    "and_chr >= 92",
+    "samsung >= 16",
+    "not dead"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@google-analytics/data':
         specifier: ^6.1.0
         version: 6.1.0
-      '@next/third-parties':
-        specifier: ^16.2.9
-        version: 16.2.9(next@16.2.9(@babel/core@7.27.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       meilisearch:
         specifier: ^0.58.0
         version: 0.58.0
@@ -1567,12 +1564,6 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@next/third-parties@16.2.9':
-    resolution: {integrity: sha512-JZPGQRN8eQs2WMfBXOf6Zjrma+JIN0KyA24MvmIa3bUI4BwTaJ1UlxmYVc5ri6l30LQ8fPv6Kmx20447hCltrg==}
-    peerDependencies:
-      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4411,9 +4402,6 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
-  third-party-capital@1.0.20:
-    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
-
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -6351,12 +6339,6 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.9':
     optional: true
-
-  '@next/third-parties@16.2.9(next@16.2.9(@babel/core@7.27.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      next: 16.2.9(@babel/core@7.27.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -9927,8 +9909,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
-
-  third-party-capital@1.0.20: {}
 
   tinyglobby@0.2.17:
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,6 @@ import {
 import { Footer } from 'src/components/Footer';
 import { JsonLd } from 'src/components/JsonLd';
 import type { Organization } from 'schema-dts';
-import { GoogleAnalytics } from '@next/third-parties/google';
 import { Header } from 'src/components/Header';
 import { Lora, Playfair_Display } from 'next/font/google';
 import { getPageTitle } from 'src/methods/getPageTitle';
@@ -73,8 +72,6 @@ export const viewport: Viewport = {
   width: 'device-width',
 };
 
-const isProduction = process.env.NODE_ENV === 'production';
-
 /**
  * https://developers.google.com/search/docs/appearance/structured-data/organization
  */
@@ -132,7 +129,6 @@ export default function RootLayout({
         </main>
         <Footer />
       </body>
-      {isProduction && <GoogleAnalytics gaId="G-KBBBK8ZDJG" />}
     </html>
   );
 }

--- a/src/app/receitas/[slug]/page.tsx
+++ b/src/app/receitas/[slug]/page.tsx
@@ -61,7 +61,8 @@ export async function generateMetadata(
   const title = `Receita de ${recipe.nome} | ${WEBSITE_NAME}`;
 
   const rawDesc = recipe.meta_descricao ?? '';
-  const description = rawDesc.length > 125 ? rawDesc.slice(0, 122) + '...' : rawDesc;
+  const description =
+    rawDesc.length > 125 ? rawDesc.slice(0, 122) + '...' : rawDesc;
 
   return {
     title,
@@ -193,10 +194,7 @@ export default async function Page(props: Props) {
             )}
 
             {/* Link para Instagram */}
-            <RecipeInstagramLinks
-              instagram_posts={recipe.instagram_posts}
-              slug={recipe.slug}
-            />
+            <RecipeInstagramLinks instagram_posts={recipe.instagram_posts} />
 
             {/* Jump to recipe - padrão conhecido de sites de receitas (Jakob's Law) */}
             {!isExclusiveRecipe && images.length > 0 && (

--- a/src/components/PagesNav.tsx
+++ b/src/components/PagesNav.tsx
@@ -1,8 +1,5 @@
-'use client';
-
 import { INSTAGRAM_USERNAME } from 'src/constants';
 import { InstagramIcon } from 'src/icons/icons';
-import { sendGAEvent } from '@next/third-parties/google';
 import Link from 'next/link';
 
 const navs = [
@@ -31,9 +28,6 @@ const navs = [
     href: `https://www.instagram.com/${INSTAGRAM_USERNAME}/`,
     label: <InstagramIcon className="text-[1.5em]" />,
     'aria-label': 'Instagram',
-    onClick: () => {
-      sendGAEvent('event', 'instagram_click');
-    },
   },
 ];
 
@@ -67,7 +61,6 @@ export const PagesNav = ({
                 aria-label={nav['aria-label']}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={nav.onClick}
                 className={linkClassName}
               >
                 {nav.label}

--- a/src/components/RecipeInstagramLinks.tsx
+++ b/src/components/RecipeInstagramLinks.tsx
@@ -1,15 +1,10 @@
-'use client';
-
 import * as React from 'react';
 import { InstagramIcon } from 'src/icons/icons';
-import { sendGAEvent } from '@next/third-parties/google';
 
 export function RecipeInstagramLinks({
   instagram_posts = [],
-  slug,
 }: {
   instagram_posts?: { url: string }[];
-  slug: string;
 }) {
   if (!instagram_posts.length) {
     return null;
@@ -26,9 +21,6 @@ export function RecipeInstagramLinks({
             href={post.url}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => {
-              sendGAEvent('event', 'instagram_click', { value: slug });
-            }}
             className="no-underline"
           >
             <span className="text-[1.5em] mr-xs align-[-3px]">

--- a/src/components/SocialNav.tsx
+++ b/src/components/SocialNav.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import {
   EMAIL,
   FACEBOOK_USERNAME,
@@ -14,7 +12,6 @@ import {
   PinterestIcon,
   TiktokIcon,
 } from 'src/icons/icons';
-import { sendGAEvent } from '@next/third-parties/google';
 
 const socialNavs = [
   {
@@ -22,35 +19,30 @@ const socialNavs = [
     label: `@${INSTAGRAM_USERNAME}`,
     href: `https://www.instagram.com/${INSTAGRAM_USERNAME}`,
     'aria-label': 'Instagram',
-    event: 'instagram_click',
   },
   {
     icon: <FacebookIcon />,
     label: `/${FACEBOOK_USERNAME}`,
     href: `https://www.facebook.com/${FACEBOOK_USERNAME}`,
     'aria-label': 'Facebook',
-    event: 'facebook_click',
   },
   {
     icon: <TiktokIcon />,
     label: `${TIKTOK_USERNAME}`,
     href: `https://www.tiktok.com/${TIKTOK_USERNAME}`,
     'aria-label': 'TikTok',
-    event: 'tiktok_click',
   },
   {
     icon: <PinterestIcon />,
     label: `/${PINTEREST_USERNAME}`,
     href: `https://www.pinterest.com/${PINTEREST_USERNAME}`,
     'aria-label': 'Pinterest',
-    event: 'pinterest_click',
   },
   {
     icon: <EnvelopeIcon />,
     label: `${EMAIL}`,
     href: `mailto:${EMAIL}`,
     'aria-label': 'Email',
-    event: 'email_click',
   },
 ];
 
@@ -75,9 +67,6 @@ export const SocialNav = ({
           rel="noopener noreferrer"
           aria-label={link.label}
           className={linkClassName}
-          onClick={() => {
-            sendGAEvent('event', link.event);
-          }}
         >
           <span className={iconClassName}>{link.icon}</span>
           {!noLabel && <span>{link.label}</span>}


### PR DESCRIPTION
## Context

PSI's **"Reduce unused JavaScript" (92 KiB)** diagnostic flagged two sources. This PR addresses both, targeting the remaining **LCP** problem (CLS was fixed in #11).

| Source | Size / Est. savings | Action |
|---|---|---|
| Google Tag Manager / `gtag.js` | 157.5 KiB / 63.8 KiB | **Removed entirely** (unused) |
| First-party polyfill chunk | 70.2 KiB / 27.9 KiB | **Modern browserslist** drops the polyfills |

## 1. Remove Google Analytics

Analytics isn't used, so it's removed completely rather than just deferred:

- Dropped `<GoogleAnalytics gaId="…">` from the root layout (and the now-unused `isProduction` const).
- Removed **all** `sendGAEvent` calls — in `PagesNav`, `SocialNav`, and `RecipeInstagramLinks`.
- **Bonus:** those three components had no other client behavior, so they shed `'use client'` and become **Server Components**, removing even more client JS.
- Removed the now-unused `@next/third-parties` dependency.

## 2. Modern browserslist

The first-party chunk shipped polyfills/transpilation for `Array.prototype.at`, `.flat`, `.flatMap`, `Object.fromEntries`, and `String.prototype.trimStart/End`, because the default browserslist targets very old browsers. Added an explicit modern target:

```json
"browserslist": [
  "chrome >= 92", "edge >= 92", "firefox >= 90",
  "safari >= 15.4", "ios_saf >= 15.4", "and_chr >= 92",
  "samsung >= 16", "not dead"
]
```

The floor (Chrome 92 / 2021, Safari 15.4 / 2022) is the minimum where **all** the flagged features are natively supported — old enough to stay inclusive of real mobile users, modern enough to stop shipping the polyfills.

## Verification

- `tsc --noEmit` passes ✅
- `prettier --check` passes ✅
- No `sendGAEvent` / `GoogleAnalytics` / `@next/third-parties` references remain ✅
- Unit tests: same 2 pre-existing `getRecipeSchema` fixture failures as on `main` (unrelated) ⚠️
- Final build validation is the Vercel preview on this PR.

## Note

This removes analytics tracking entirely. If you ever want lightweight, privacy-friendly analytics later, that can be added back behind a deferred/`lazyOnload` strategy without the CWV cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL6DWMkD34GDxowyoM4n27

---
_Generated by [Claude Code](https://claude.ai/code/session_01UL6DWMkD34GDxowyoM4n27)_