### PR TITLE
fix(cms): tag recipe listing/sitemap fetches for webhook revalidation

### DIFF
--- a/src/cms/recipes.ts
+++ b/src/cms/recipes.ts
@@ -121,7 +121,9 @@ export const getRecipes = async (args: {
     })}`;
   })();
 
-  const response = await cmsFetch<CMSRecipesResponse>(url);
+  const response = await cmsFetch<CMSRecipesResponse>(url, {
+    next: { tags: [CMS_RECIPES_TAG] },
+  });
 
   return response;
 };
@@ -219,7 +221,8 @@ export const getRecipesWithPagination = async ({
   });
 
   const response = await cmsFetch<CMSRecipesResponse>(
-    `${CMS_URL}/api/lets-cozinha-receitas?${query}`
+    `${CMS_URL}/api/lets-cozinha-receitas?${query}`,
+    { next: { tags: [CMS_RECIPES_TAG] } }
   );
 
   return response;
@@ -246,7 +249,8 @@ export const getAllSimplifiedRecipes = async () => {
     });
 
     const response = await cmsFetch<CMSDataArrayResponse<SimplifiedRecipe>>(
-      `${CMS_URL}/api/lets-cozinha-receitas?${query}`
+      `${CMS_URL}/api/lets-cozinha-receitas?${query}`,
+      { next: { tags: [CMS_RECIPES_TAG] } }
     );
 
     return response;


### PR DESCRIPTION
## Problem

Recipe **detail** pages are already purgeable via `revalidateTag('cms-recipes')` (called by the CMS webhook through `/api/revalidate`). But the card-profile **listing** fetches were not tagged — they used `force-cache` with no tag and no `revalidate`, so they only refreshed on **redeploy**.

Affected fetches in `src/cms/recipes.ts`:
- `getRecipes` — category pages and related-recipe lists
- `getRecipesWithPagination` — the `/receitas` listing
- `getAllSimplifiedRecipes` — the **sitemap**

Result: after a recipe was added/edited, the detail page updated promptly, but listings and the sitemap stayed stale until the next deploy.

## Fix

Add `{ next: { tags: [CMS_RECIPES_TAG] } }` to all three fetches so the **existing** webhook (`/api/revalidate` with `tags: ['cms-recipes']`) purges them alongside the detail pages. No new infrastructure — just bringing these fetches into the tag that's already wired up.

## Verification

- `tsc --noEmit` passes ✅
- `prettier --check` passes ✅
- Single-file change (`src/cms/recipes.ts`), no behavior change beyond cache tagging
- Final build validation is the Vercel preview on this PR

## Note

This is independent of #11 (CLS) and #12 (GA removal) — different file, no overlap. `searchSimilarRecipes` / `getRecommendedEbook` remain `revalidate: false` and untagged (recommendations changing only on deploy is acceptable); can revisit later if you want those refreshed by the webhook too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL6DWMkD34GDxowyoM4n27

---
_Generated by [Claude Code](https://claude.ai/code/session_01UL6DWMkD34GDxowyoM4n27)_