### PR TITLE
fix(typography): restore fonts after Pages Router migration

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
+import { Playfair_Display, Lora } from 'next/font/google';
 import { Header } from 'src/components/Header';
 import { Footer } from 'src/components/Footer';
 import { Container } from 'src/components/Container';
@@ -20,6 +21,16 @@ import { getWebsiteName } from 'src/methods/getWebsiteName';
 import type { AsideData } from 'src/methods/getAsideData';
 import '../styles/fa.css';
 import '../styles/globals.css';
+
+const playfairDisplay = Playfair_Display({
+  subsets: ['latin'],
+  variable: '--font-playfair-display',
+});
+
+const lora = Lora({
+  subsets: ['latin'],
+  variable: '--font-lora',
+});
 
 const organizationSchema: Organization = {
   '@type': 'Organization',
@@ -42,6 +53,8 @@ export default function App({ Component, pageProps }: AppProps) {
   const { asideData, ...componentProps } = pageProps as CommonPageProps &
     Record<string, unknown>;
 
+  const fontClasses = `${playfairDisplay.variable} ${lora.variable}`;
+
   return (
     <>
       <Head>
@@ -53,25 +66,27 @@ export default function App({ Component, pageProps }: AppProps) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <JsonLd schema={organizationSchema} />
-      <Header />
+      <div className={`${fontClasses} font-body`}>
+        <JsonLd schema={organizationSchema} />
+        <Header />
 
-      <main className="pb-xl md:pb-2xl">
-        <Container>
-          <div className="mx-auto my-lg md:my-xl flex flex-col md:flex-row gap-sm md:gap-xl min-h-screen">
-            <div className={asideData ? 'w-full md:w-[70%]' : 'w-full'}>
-              <Component {...componentProps} />
-            </div>
-            {asideData && (
-              <div className="w-full md:w-[30%]">
-                <LayoutAside data={asideData} />
+        <main className="pb-xl md:pb-2xl">
+          <Container>
+            <div className="mx-auto my-lg md:my-xl flex flex-col md:flex-row gap-sm md:gap-xl min-h-screen">
+              <div className={asideData ? 'w-full md:w-[70%]' : 'w-full'}>
+                <Component {...componentProps} />
               </div>
-            )}
-          </div>
-        </Container>
-      </main>
+              {asideData && (
+                <div className="w-full md:w-[30%]">
+                  <LayoutAside data={asideData} />
+                </div>
+              )}
+            </div>
+          </Container>
+        </main>
 
-      <Footer descricao={asideData?.siteDescricao ?? undefined} />
+        <Footer descricao={asideData?.siteDescricao ?? undefined} />
+      </div>
     </>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import { Playfair_Display, Lora } from 'next/font/google';
 import { Header } from 'src/components/Header';
 import { Footer } from 'src/components/Footer';
 import { Container } from 'src/components/Container';
@@ -21,16 +20,6 @@ import { getWebsiteName } from 'src/methods/getWebsiteName';
 import type { AsideData } from 'src/methods/getAsideData';
 import '../styles/fa.css';
 import '../styles/globals.css';
-
-const playfairDisplay = Playfair_Display({
-  subsets: ['latin'],
-  variable: '--font-playfair-display',
-});
-
-const lora = Lora({
-  subsets: ['latin'],
-  variable: '--font-lora',
-});
 
 const organizationSchema: Organization = {
   '@type': 'Organization',
@@ -53,8 +42,6 @@ export default function App({ Component, pageProps }: AppProps) {
   const { asideData, ...componentProps } = pageProps as CommonPageProps &
     Record<string, unknown>;
 
-  const fontClasses = `${playfairDisplay.variable} ${lora.variable}`;
-
   return (
     <>
       <Head>
@@ -69,7 +56,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <JsonLd schema={organizationSchema} />
       <Header />
 
-      <main className={`pb-xl md:pb-2xl ${fontClasses}`}>
+      <main className="pb-xl md:pb-2xl">
         <Container>
           <div className="mx-auto my-lg md:my-xl flex flex-col md:flex-row gap-sm md:gap-xl min-h-screen">
             <div className={asideData ? 'w-full md:w-[70%]' : 'w-full'}>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,22 +1,8 @@
 import { Html, Head, Main, NextScript } from 'next/document';
-import { Playfair_Display, Lora } from 'next/font/google';
-
-const playfairDisplay = Playfair_Display({
-  subsets: ['latin'],
-  variable: '--font-playfair-display',
-});
-
-const lora = Lora({
-  subsets: ['latin'],
-  variable: '--font-lora',
-});
 
 export default function Document() {
   return (
-    <Html
-      lang="pt-br"
-      className={`${playfairDisplay.variable} ${lora.variable}`}
-    >
+    <Html lang="pt-br">
       <Head>
         <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
       </Head>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,8 +1,22 @@
 import { Html, Head, Main, NextScript } from 'next/document';
+import { Playfair_Display, Lora } from 'next/font/google';
+
+const playfairDisplay = Playfair_Display({
+  subsets: ['latin'],
+  variable: '--font-playfair-display',
+});
+
+const lora = Lora({
+  subsets: ['latin'],
+  variable: '--font-lora',
+});
 
 export default function Document() {
   return (
-    <Html lang="pt-br">
+    <Html
+      lang="pt-br"
+      className={`${playfairDisplay.variable} ${lora.variable}`}
+    >
       <Head>
         <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
       </Head>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,12 +2,6 @@
 
 @theme {
   --font-*: initial;
-  --font-heading:
-    var(--font-playfair-display), ui-serif, Georgia, Cambria, 'Times New Roman',
-    Times, serif;
-  --font-body:
-    var(--font-lora), ui-serif, Georgia, Cambria, 'Times New Roman', Times,
-    serif;
 
   --radius: 4px;
 
@@ -35,6 +29,15 @@
   --spacing-image-sm: 8rem;
   --spacing-image-lg: 42rem;
   --spacing-article: 800px;
+}
+
+@theme inline {
+  --font-heading:
+    var(--font-playfair-display), ui-serif, Georgia, Cambria, 'Times New Roman',
+    Times, serif;
+  --font-body:
+    var(--font-lora), ui-serif, Georgia, Cambria, 'Times New Roman', Times,
+    serif;
 }
 
 @utility container {
@@ -70,6 +73,7 @@
   }
 
   body {
+    @apply font-body;
     @apply bg-neutral;
     @apply text-text-dark;
     @apply leading-relaxed;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -70,7 +70,6 @@
   }
 
   body {
-    @apply font-body;
     @apply bg-neutral;
     @apply text-text-dark;
     @apply leading-relaxed;


### PR DESCRIPTION
## Problem

After migrating from App Router to Pages Router, the custom Google Fonts (Playfair Display and Lora) stopped working. The font CSS variables (`--font-playfair-display`, `--font-lora`) were only applied to `<main>` in `_app.tsx`, but `globals.css` references them on `body`, `h1–h6`, and all inherited text — including inside `<Header>` and `<Footer>` which live outside `<main>`.

Because CSS custom properties can't flow *up* the DOM tree, `body { @apply font-body }` resolved `--font-lora` as unset, falling back to the browser's default serif font. Headings and body text throughout the page lost Playfair Display and Lora.

## Fix

Move the font definitions from `_app.tsx` to `_document.tsx` and apply the variable classes to `<Html>`. This makes `--font-playfair-display` and `--font-lora` available at the root level, so every selector in `globals.css` (`body`, `h1–h6`, etc.) can resolve them correctly — including Header and Footer.

**Files changed:**
- `src/pages/_document.tsx` — define fonts here, apply `className` to `<Html>`
- `src/pages/_app.tsx` — remove duplicate font definitions and `fontClasses` from `<main>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScHamhgRZojKaVrD2NjynJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScHamhgRZojKaVrD2NjynJ)_